### PR TITLE
fix: use supported shorthand for github repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
       "url": "https://www.patreon.com/koistya"
     }
   ],
-  "repository": "kriasoft/web-auth-library",
+  "repository": "github:kriasoft/web-auth-library",
   "keywords": [
     "auth",
     "authentication",


### PR DESCRIPTION
**Problem**

The [npm page of web-auth-library](https://www.npmjs.com/package/web-auth-library) does not display the repository link.

**Solution**

Using one of the official formats for the repository field allows npm to add a link to the npm page of the module.

See https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository