### PR TITLE
fix: define content-type header for token fetch

### DIFF
--- a/google/accessToken.ts
+++ b/google/accessToken.ts
@@ -99,7 +99,11 @@ export async function getAccessToken(options: Options) {
       const body = new URLSearchParams();
       body.append("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer");
       body.append("assertion", jwt);
-      res = await fetch(tokenUrl, { method: "POST", body });
+      res = await fetch(tokenUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body,
+      });
 
       if (!res.ok) {
         const error = await res


### PR DESCRIPTION
**Problem**
Running `getAccessToken` with https://github.com/oven-sh/bun as the runtime produces the following error response for the fetch call that should retrieve the oauth access token.
```json
{
  "ok": false,
  "url": "https://oauth2.googleapis.com/token",
  "statusText": "Bad Request",
  "redirected": false,
  "bodyUsed": true,
  "status": 400
}
```

**Solution**
Define content type in headers to avoid 400 bad request response. 

Worth noting I cannot reproduce the problem with Cloudflare workers. The content type seems to be auto-detected somewhere along the chain. However, it shouldn't hurt explicitly defining it anyway.