### PR TITLE
fix: avoid throwing if caches is undeclared

### DIFF
--- a/core/env.ts
+++ b/core/env.ts
@@ -1,4 +1,6 @@
 /* SPDX-FileCopyrightText: 2022-present Kriasoft */
 /* SPDX-License-Identifier: MIT */
 
-export const canUseDefaultCache = typeof caches?.default?.put === "function";
+export const canUseDefaultCache =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  typeof (globalThis as any).caches?.default?.put === "function";


### PR DESCRIPTION
**Problem**
Using `getAccessToken` with a runtime that does not support the global `caches` property throws a reference error in any runtime that does not support the CacheStorage api. This happens during the support check for the default cache, which refers to the `caches` directly without having verified the support yet.

**Solution**
Use `globalThis.caches` to verify the reference.