### PR TITLE
chore(types): Tweak `options.waitUntil` to use `Promise<any>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ app.get("/", ({ env, executionCtx, json }) => {
 You're very welcome to [create a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
 or send me a message on [Discord](https://discord.gg/bSsv7XM).
 
+In order to unit test this library locally you will need [Node.js](https://nodejs.org/) v18+ with [corepack enabled](https://nodejs.org/api/corepack.html), a Google Cloud [service account key](https://cloud.google.com/iam/docs/keys-create-delete) ([here](https://console.cloud.google.com/iam-admin/serviceaccounts)) and Firebase API Key ([here](https://console.cloud.google.com/apis/credentials)) that you can save into the [`test/test.override.env`](./test/test.env) file, for example:
+
+```
+GOOGLE_CLOUD_PROJECT=example
+GOOGLE_CLOUD_CREDENTIALS={"type":"service_account","project_id":"example",...}
+FIREBASE_API_KEY=AIzaSyAZEmdfRWvEYgZpwm6EBLkYJf6ySIMF3Hy
+```
+
+Then run unit tests via `yarn test [--watch]`.
+
 ## License
 
 Copyright © 2022-present Kriasoft. This source code is licensed under the MIT license found in the

--- a/core/env.ts
+++ b/core/env.ts
@@ -1,4 +1,5 @@
 /* SPDX-FileCopyrightText: 2022-present Kriasoft */
 /* SPDX-License-Identifier: MIT */
 
-export const canUseDefaultCache = typeof caches?.default?.put === "function";
+export const canUseDefaultCache =
+  typeof self.caches?.default?.put === "function";

--- a/google/accessToken.ts
+++ b/google/accessToken.ts
@@ -99,7 +99,11 @@ export async function getAccessToken(options: Options) {
       const body = new URLSearchParams();
       body.append("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer");
       body.append("assertion", jwt);
-      res = await fetch(tokenUrl, { method: "POST", body });
+      res = await fetch(tokenUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body,
+      });
 
       if (!res.ok) {
         const error = await res
@@ -171,7 +175,8 @@ type Options = {
      */
     GOOGLE_CLOUD_CREDENTIALS: string;
   };
-  waitUntil?: <T = unknown>(promise: Promise<T>) => void;
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  waitUntil?: (promise: Promise<any>) => void;
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   cache?: Map<string, any>;
 };

--- a/google/credentials.ts
+++ b/google/credentials.ts
@@ -43,7 +43,8 @@ export async function importPublicKey(options: {
    * @default "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com"
    */
   certificateURL?: string;
-  waitUntil?: <T = unknown>(promise: Promise<T>) => void;
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  waitUntil?: (promise: Promise<any>) => void;
 }) {
   const keyId = options.keyId;
   const certificateURL = options.certificateURL ?? "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com"; // prettier-ignore

--- a/google/idToken.ts
+++ b/google/idToken.ts
@@ -180,7 +180,8 @@ export async function verifyIdToken(options: {
      */
     GOOGLE_CLOUD_CREDENTIALS?: string;
   };
-  waitUntil?: <T = unknown>(promise: Promise<T>) => void;
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  waitUntil?: (promise: Promise<any>) => void;
 }): Promise<UserToken> {
   if (!options?.idToken) {
     throw new TypeError(`Missing "idToken"`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-auth-library",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "packageManager": "yarn@4.0.0-rc.39",
   "description": "Authentication library for the browser environment using Web Crypto API",
   "license": "MIT",
@@ -26,7 +26,7 @@
       "url": "https://www.patreon.com/koistya"
     }
   ],
-  "repository": "kriasoft/web-auth-library",
+  "repository": "github:kriasoft/web-auth-library",
   "keywords": [
     "auth",
     "authentication",


### PR DESCRIPTION
- Relax `option.waitUntil` TypeScript method signature to make it less strict.
- Explicitly send `application/x-www-form-urlencoded` header when requesting an access token