### PR TITLE
Support Google Cloud Gmail service

### DIFF
--- a/google/accessToken.ts
+++ b/google/accessToken.ts
@@ -95,6 +95,7 @@ export async function getAccessToken(options: Options) {
       const jwt = await createCustomToken({
         credentials,
         scope: options.audience ?? options.scope,
+        subject: options.subject,
       });
       const body = new URLSearchParams();
       body.append("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer");
@@ -160,6 +161,10 @@ type Options = {
    * Authentication scope(s).
    */
   scope?: string[] | string;
+  /**
+   * The principal that is the subject of the JWT.
+   */
+  subject?: string;
   /**
    * Recipients that the ID token should be issued for.
    */


### PR DESCRIPTION
In order to use a Google Cloud service account to send email via Gmail, you need to add the `subject` property when requesting the access token. Using `googleapis`, per https://github.com/googleapis/google-cloud-node/issues/7801, this is done via:

```js
const auth = new google.auth.GoogleAuth({
  keyFile: 'google-cloud-credentials.json',
  scopes: [
    'https://www.googleapis.com/auth/gmail.send',
  ],
  clientOptions: {
    subject: 'service-account-email@yourdomain.com',
  },
})
```

Something similar can _almost_ be done with `web-auth-library`, however the `subject` option isn’t currently getting passed down from `getAccessToken` to `createCustomToken`. This PR adds it, and adds it to the type.

I also added a full example showing how to send an email via Google Cloud and Gmail. Apologies for the length. I’ve tested the code in that example using my own service account and it works.

I don’t have a Firebase account and I don’t think my Google Cloud service account has all the permissions necessary to run the test suite, so I didn’t try to add a test for this. Sorry. Hopefully this is a tiny enough change that you can accept it as is, or you can adapt my readme example into a new test.